### PR TITLE
fix: update listener to use correct data contract for event payload

### DIFF
--- a/harbor/types.go
+++ b/harbor/types.go
@@ -40,7 +40,6 @@ type Repository struct {
 // Resource is...
 type Resource struct {
 	Digest       string        `json:"digest"`
-	Tag          string        `json:"tag"`
 	ResourceUrl  string        `json:"resource_url"`
 	ScanOverview *ScanOverview `json:"scan_overview"`
 }

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -154,7 +154,7 @@ func createDiscoveryOccurrences(event *harbor.Event, resource *harbor.Resource, 
 	return []*grafeas_go_proto.Occurrence{
 		{
 			Resource: &grafeas_go_proto.Resource{
-				Uri: resourceUri(resource),
+				Uri: resource.ResourceUrl,
 			},
 			NoteName:   noteName,
 			Kind:       common_go_proto.NoteKind_DISCOVERY,
@@ -169,7 +169,7 @@ func createDiscoveryOccurrences(event *harbor.Event, resource *harbor.Resource, 
 		},
 		{
 			Resource: &grafeas_go_proto.Resource{
-				Uri: resourceUri(resource),
+				Uri: resource.ResourceUrl,
 			},
 			NoteName:   noteName,
 			Kind:       common_go_proto.NoteKind_DISCOVERY,
@@ -195,7 +195,7 @@ func (l *listener) createVulnerabilityOccurrences(event *harbor.Event, resource 
 	for _, vulnerability := range report.Vulnerabilities {
 		occurrence := &grafeas_go_proto.Occurrence{
 			Resource: &grafeas_go_proto.Resource{
-				Uri: resourceUri(resource),
+				Uri: resource.ResourceUrl,
 			},
 			NoteName:   noteName,
 			Kind:       common_go_proto.NoteKind_VULNERABILITY,
@@ -246,12 +246,6 @@ func (l *listener) createNoteForReport(ctx context.Context, event *harbor.Event,
 	}
 
 	return note.Name, nil
-}
-
-func resourceUri(resource *harbor.Resource) string {
-	base := strings.Split(resource.ResourceUrl, ":")[0]
-
-	return fmt.Sprintf("%s@%s", base, resource.Digest)
 }
 
 func eventTimestamp(event *harbor.Event) *timestamppb.Timestamp {

--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -81,7 +81,7 @@ var _ = Describe("listener", func() {
 
 		BeforeEach(func() {
 			expectedPayload = nil
-			expectedUrl = fake.URL()
+			expectedUrl = fake.DomainName()
 			recorder = httptest.NewRecorder()
 
 			expectedArtifactUrl = fake.URL()
@@ -218,10 +218,12 @@ var _ = Describe("listener", func() {
 				Expect(scanStartOccurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
 				Expect(scanStartOccurrence.NoteName).To(Equal(expectedNoteName))
 				Expect(scanStartOccurrence.Details.(*grafeas_go_proto.Occurrence_Discovered).Discovered.Discovered.AnalysisStatus).To(Equal(discovery_go_proto.Discovered_SCANNING))
+				Expect(scanStartOccurrence.Resource.Uri).To(MatchRegexp("%s@sha256:.+", expectedUrl))
 
 				Expect(scanEndOccurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
 				Expect(scanEndOccurrence.NoteName).To(Equal(expectedNoteName))
 				Expect(scanEndOccurrence.Details.(*grafeas_go_proto.Occurrence_Discovered).Discovered.Discovered.AnalysisStatus).To(Equal(discovery_go_proto.Discovered_FINISHED_FAILED))
+				Expect(scanEndOccurrence.Resource.Uri).To(MatchRegexp("%s@sha256:.+", expectedUrl))
 			})
 
 			It("should respond with a 200", func() {
@@ -297,10 +299,12 @@ var _ = Describe("listener", func() {
 				Expect(scanStartOccurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
 				Expect(scanStartOccurrence.NoteName).To(Equal(expectedNoteName))
 				Expect(scanStartOccurrence.Details.(*grafeas_go_proto.Occurrence_Discovered).Discovered.Discovered.AnalysisStatus).To(Equal(discovery_go_proto.Discovered_SCANNING))
+				Expect(scanStartOccurrence.Resource.Uri).To(MatchRegexp("%s@sha256:.+", expectedUrl))
 
 				Expect(scanEndOccurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
 				Expect(scanEndOccurrence.NoteName).To(Equal(expectedNoteName))
 				Expect(scanEndOccurrence.Details.(*grafeas_go_proto.Occurrence_Discovered).Discovered.Discovered.AnalysisStatus).To(Equal(discovery_go_proto.Discovered_FINISHED_SUCCESS))
+				Expect(scanEndOccurrence.Resource.Uri).To(MatchRegexp("%s@sha256:.+", expectedUrl))
 			})
 
 			It("should respond with a 200", func() {
@@ -338,10 +342,12 @@ var _ = Describe("listener", func() {
 					Expect(scanStartOccurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
 					Expect(scanStartOccurrence.NoteName).To(Equal(expectedNoteName))
 					Expect(scanStartOccurrence.Details.(*grafeas_go_proto.Occurrence_Discovered).Discovered.Discovered.AnalysisStatus).To(Equal(discovery_go_proto.Discovered_SCANNING))
+					Expect(scanStartOccurrence.Resource.Uri).To(MatchRegexp("%s@sha256:.+", expectedUrl))
 
 					Expect(scanEndOccurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
 					Expect(scanEndOccurrence.NoteName).To(Equal(expectedNoteName))
 					Expect(scanEndOccurrence.Details.(*grafeas_go_proto.Occurrence_Discovered).Discovered.Discovered.AnalysisStatus).To(Equal(discovery_go_proto.Discovered_FINISHED_SUCCESS))
+					Expect(scanEndOccurrence.Resource.Uri).To(MatchRegexp("%s@sha256:.+", expectedUrl))
 
 					for i := 0; i < len(expectedReport.Vulnerabilities); i++ {
 						occurrence := batchCreateOccurrencesRequest.Occurrences[i+2]
@@ -473,7 +479,6 @@ func generateRandomTime() int64 {
 
 func generateRandomResource(expectedUrl, expectedReportId string) *harbor.Resource {
 	randomDigest := sha256.Sum256([]byte(fake.LetterN(10)))
-	randomTag := fake.LetterN(7)
 
 	return &harbor.Resource{
 		ScanOverview: &harbor.ScanOverview{
@@ -492,8 +497,7 @@ func generateRandomResource(expectedUrl, expectedReportId string) *harbor.Resour
 			},
 		},
 		Digest:      fmt.Sprintf("sha256:%x", randomDigest),
-		Tag:         randomTag,
-		ResourceUrl: fmt.Sprintf("%s:%s", expectedUrl, randomTag),
+		ResourceUrl: fmt.Sprintf("%s@sha256:%s", expectedUrl, randomDigest),
 	}
 }
 


### PR DESCRIPTION
example buggy payload:

```json
{
  "type": "SCANNING_COMPLETED",
  "occur_at": 1627311461,
  "operator": "auto",
  "event_data": {
    "resources": [
      {
        "digest": "sha256:51688849b754d86f67122de9d3c4569d6561092c8877c83439e65ce7b4ed1376",
        "tag": "",
        "resource_url": "harbor.parker.gg/rode-demo/rode-demo-node-app:",
        "scan_overview": {
          "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
            "report_id": "2cd3325c-f311-4b15-b72e-9cd055d4750b",
            "scan_status": "Success",
            "severity": "Unknown",
            "duration": 20,
            "summary": {
              "total": 0,
              "fixable": 0,
              "summary": {}
            },
            "start_time": "2021-07-26T14:57:21.704901Z",
            "end_time": "2021-07-26T14:57:41.681625Z",
            "scanner": {
              "name": "Trivy",
              "vendor": "Aqua Security",
              "version": "v0.9.2"
            },
            "complete_percent": 100
          }
        }
      }
    ],
    "repository": {
      "name": "rode-demo-node-app",
      "namespace": "rode-demo",
      "repo_full_name": "rode-demo/rode-demo-node-app",
      "repo_type": "private"
    }
  }
}

```

example fixed payload:

```json
{
  "type": "SCANNING_COMPLETED",
  "occur_at": 1627314007,
  "operator": "auto",
  "event_data": {
    "resources": [
      {
        "digest": "sha256:91bce4224ad68568ec94b436fcb8960bef3f640a7e4a15e80f04681faf4c2ccf",
        "resource_url": "harbor.parker.gg/rode-demo/rode-demo-node-app@sha256:91bce4224ad68568ec94b436fcb8960bef3f640a7e4a15e80f04681faf4c2ccf",
        "scan_overview": {
          "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
            "report_id": "682b143e-f387-42c7-a241-99fd4f2f4120",
            "scan_status": "Success",
            "severity": "Unknown",
            "duration": 8,
            "summary": {
              "total": 0,
              "fixable": 0,
              "summary": {}
            },
            "start_time": "2021-07-26T15:39:58Z",
            "end_time": "2021-07-26T15:40:06Z",
            "scanner": {
              "name": "Trivy",
              "vendor": "Aqua Security",
              "version": "v0.16.0"
            },
            "complete_percent": 100
          },
          "application/vnd.security.vulnerability.report; version=1.1": {
            "report_id": "b65d4fb5-9bac-4edc-98b9-6b3cc299b9dd",
            "scan_status": "Success",
            "severity": "Unknown",
            "duration": 8,
            "summary": {
              "total": 0,
              "fixable": 0,
              "summary": {}
            },
            "start_time": "2021-07-26T15:39:58Z",
            "end_time": "2021-07-26T15:40:06Z",
            "scanner": {
              "name": "Trivy",
              "vendor": "Aqua Security",
              "version": "v0.16.0"
            },
            "complete_percent": 100
          }
        }
      }
    ],
    "repository": {
      "name": "rode-demo-node-app",
      "namespace": "rode-demo",
      "repo_full_name": "rode-demo/rode-demo-node-app",
      "repo_type": "private"
    }
  }
}
```

the only relevant change is that `resource_url` can be used directly without having to build it from other properties